### PR TITLE
Better handling of 'unavailable' property

### DIFF
--- a/androidtv/__init__.py
+++ b/androidtv/__init__.py
@@ -239,6 +239,10 @@ class AndroidTV:
             try:
                 self._adb_client = AdbClient(host=self.adb_server_ip, port=self.adb_server_port)
                 self._adb_device = self._adb_client.device(self.host)
+                if self._adb_device is None:
+                    self._adb = False
+                else:
+                    self._adb = True
             except:
                 self._adb = False
 
@@ -341,7 +345,8 @@ class AndroidTV:
             # make sure the device is available
             try:
                 if any([self.host in dev.get_serial_no() for dev in adb_devices]):
-                    self._adb = True
+                    if not self._adb:
+                        self._adb = True
                     return True
                 else:
                     if self._adb:

--- a/androidtv/__init__.py
+++ b/androidtv/__init__.py
@@ -200,6 +200,7 @@ class AndroidTV:
         self._adb = None  # python-adb
         self._adb_client = None  # pure-python-adb
         self._adb_device = None  # pure-python-adb
+        self._available = None # pure-python-adb
 
         # the method used for sending ADB commands
         if not self.adb_server_ip:
@@ -240,11 +241,11 @@ class AndroidTV:
                 self._adb_client = AdbClient(host=self.adb_server_ip, port=self.adb_server_port)
                 self._adb_device = self._adb_client.device(self.host)
                 if self._adb_device is None:
-                    self._adb = False
+                    self._available = False
                 else:
-                    self._adb = True
+                    self._available = True
             except:
-                self._adb = False
+                self._available = False
 
     def update(self):
         """ Update the device status. """
@@ -345,25 +346,25 @@ class AndroidTV:
             # make sure the device is available
             try:
                 if any([self.host in dev.get_serial_no() for dev in adb_devices]):
-                    if not self._adb:
-                        self._adb = True
+                    if not self._available:
+                        self._available = True
                     return True
                 else:
-                    if self._adb:
+                    if self._available:
                         logging.error('ADB server is not connected to the device.')
-                        self._adb = False
+                        self._available = False
                     return False
 
             except RuntimeError:
-                if self._adb:
+                if self._available:
                     logging.error('ADB device is unavailable; encountered an error when searching for device.')
-                    self._adb = False
+                    self._available = False
                 return False
 
         except RuntimeError:
-            if self._adb:
+            if self._available:
                 logging.error('ADB server is unavailable.')
-                self._adb = False
+                self._available = False
             return False
 
     @property

--- a/androidtv/__init__.py
+++ b/androidtv/__init__.py
@@ -224,11 +224,15 @@ class AndroidTV:
                     signer = Signer(self.adbkey)
 
                     # Connect to the device
-                    self._adb = adb_commands.AdbCommands().ConnectDevice(serial=self.host, rsa_keys=[signer])
+                    self._adb = adb_commands.AdbCommands().ConnectDevice(serial=self.host, rsa_keys=[signer], default_timeout_ms=9000)
                 else:
                     self._adb = adb_commands.AdbCommands().ConnectDevice(serial=self.host)
             except socket_error as serr:
-                logging.warning("Couldn't connect to host: %s, error: %s", self.host, serr.strerror)
+                if bool(self._adb):
+                    self._adb = False
+                    if serr.strerror is None:
+                        serr.strerror = "Timed out trying to connect to ADB device."
+                    logging.warning("Couldn't connect to host: %s, error: %s", self.host, serr.strerror)
 
         else:
             # pure-python-adb

--- a/androidtv/__init__.py
+++ b/androidtv/__init__.py
@@ -196,7 +196,7 @@ class AndroidTV:
         self.app_id = None
         # self.app_name = None
 
-        # the attributes used for sending ADB commands; filled in `self.connect()`
+        # the attributes used for sending ADB commands; filled in in `self.connect()`
         self._adb = None  # python-adb
         self._adb_client = None  # pure-python-adb
         self._adb_device = None  # pure-python-adb
@@ -347,7 +347,7 @@ class AndroidTV:
                     if self._adb:
                         logging.error('ADB server is not connected to the device.')
                         self._adb = False
-                        return False
+                    return False
 
             except RuntimeError:
                 if self._adb:

--- a/androidtv/__init__.py
+++ b/androidtv/__init__.py
@@ -194,7 +194,6 @@ class AndroidTV:
         self.device = None
         self.volume = 0.
         self.app_id = None
-        self._available = None
         # self.app_name = None
 
         # the attributes used for sending ADB commands; filled in `self.connect()`
@@ -342,24 +341,24 @@ class AndroidTV:
             # make sure the device is available
             try:
                 if any([self.host in dev.get_serial_no() for dev in adb_devices]):
-                    self._available = True
+                    self._adb = True
                     return True
                 else:
-                    if self._available:
+                    if self._adb:
                         logging.error('ADB server is not connected to the device.')
-                        self._available = False
+                        self._adb = False
                         return False
 
             except RuntimeError:
-                if self._available:
+                if self._adb:
                     logging.error('ADB device is unavailable; encountered an error when searching for device.')
-                    self._available = False
+                    self._adb = False
                 return False
 
         except RuntimeError:
-            if self._available:
+            if self._adb:
                 logging.error('ADB server is unavailable.')
-                self._available = False
+                self._adb = False
             return False
 
     @property


### PR DESCRIPTION
As per the official docs (https://developers.home-assistant.io/docs/en/integration_quality_scale_index.html#silver), "Handles device/service unavailable. Log a warning once when unavailable, log once when reconnected."

So I modified the connect funcion to only warn about an error if it has not been logged before.
Also, even if the device is unavailable, the logs would be filled with 'Update taking longer than 10s' every updates, to prevent that I added a timeout to ADB's connect function, and now everything is working as expected and the logs are not flooded. Also without this timeout, it would cause a delay of ~20s while launching HA.