### PR TITLE
Improved current app and media session state

### DIFF
--- a/androidtv/androidtv.py
+++ b/androidtv/androidtv.py
@@ -4,7 +4,6 @@ ADB Debugging must be enabled.
 """
 
 
-
 from .basetv import BaseTV
 from . import constants
 
@@ -98,6 +97,10 @@ class AndroidTV(BaseTV):
                 state = constants.STATE_PLAYING
             else:
                 state = constants.STATE_STANDBY
+
+        # Plex
+        elif current_app == constants.APP_PLEX:
+            state = audio_state
 
         # Get the state from `media_session_state`
         elif media_session_state:

--- a/androidtv/basetv.py
+++ b/androidtv/basetv.py
@@ -352,9 +352,11 @@ class BaseTV(object):
             The ID of the current app, or ``None`` if it could not be determined
 
         """
-        current_window = self.adb_shell(constants.CMD_CURRENT_APP)
+        current_app = self.adb_shell(constants.CMD_CURRENT_APP_FULL)
 
-        return self._current_app(current_window)
+        if current_app:
+            return current_app
+        return None
 
     @property
     def device(self):
@@ -394,7 +396,7 @@ class BaseTV(object):
             The state from the output of the ADB shell command ``dumpsys media_session``, or ``None`` if it could not be determined
 
         """
-        media_session = self.adb_shell(constants.CMD_MEDIA_SESSION_STATE)
+        media_session = self.adb_shell(constants.CMD_MEDIA_SESSION_STATE_FULL)
 
         return self._media_session_state(media_session)
 
@@ -497,34 +499,6 @@ class BaseTV(object):
             return constants.STATE_PAUSED
 
         return constants.STATE_IDLE
-
-    @staticmethod
-    def _current_app(current_window):
-        """Return the current app from the output of ``adb shell dumpsys window windows | grep mCurrentFocus``.
-
-        Parameters
-        ----------
-        current_window : str, None
-            The output of ``adb shell dumpsys window windows | grep mCurrentFocus``
-
-        Returns
-        -------
-        str, None
-            The ID of the current app, or ``None`` if it could not be determined
-
-        """
-        if current_window is None:
-            return None
-
-        current_window = current_window.replace("\r", "")
-        matches = constants.REGEX_WINDOW.search(current_window)
-
-        # case 1: current app was successfully found
-        if matches:
-            return matches.group('package')
-
-        # case 2: current app could not be found
-        return None
 
     @staticmethod
     def _device(stream_music):

--- a/androidtv/constants.py
+++ b/androidtv/constants.py
@@ -13,8 +13,10 @@ CMD_SUCCESS1_FAILURE0 = r" && echo -e '1\c' || echo -e '0\c'"
 # ADB shell commands for getting various properties
 CMD_AUDIO_STATE = r"dumpsys audio | grep -q paused && echo -e '1\c' || (dumpsys audio | grep -q started && echo '2\c' || echo '0\c')"
 CMD_AWAKE = "dumpsys power | grep mWakefulness | grep -q Awake"
-CMD_CURRENT_APP = "dumpsys window windows | grep mCurrentFocus"
-CMD_MEDIA_SESSION_STATE = "dumpsys media_session | grep -m 1 'state=PlaybackState {'"
+CMD_CURRENT_APP = "CURRENT_APP=$(dumpsys window windows | grep mCurrentFocus) && CURRENT_APP=${CURRENT_APP#* * } && CURRENT_APP=${CURRENT_APP%%/*}"
+CMD_CURRENT_APP_FULL = CMD_CURRENT_APP + " && echo $CURRENT_APP"
+CMD_MEDIA_SESSION_STATE = "dumpsys media_session | grep -A 100 'Sessions Stack' | grep -A 100 $CURRENT_APP | grep -m 1 'state=PlaybackState {'"
+CMD_MEDIA_SESSION_STATE_FULL = CMD_CURRENT_APP + " && " + CMD_MEDIA_SESSION_STATE
 CMD_RUNNING_APPS = "ps | grep u0_a"
 CMD_SCREEN_ON = "dumpsys power | grep 'Display Power' | grep -q 'state=ON'"
 CMD_WAKE_LOCK_SIZE = "dumpsys power | grep Locks | grep 'size='"
@@ -218,7 +220,6 @@ APPS = {APP_AMAZON_VIDEO: 'Amazon Video',
 
 # Regular expressions
 REGEX_MEDIA_SESSION_STATE = re.compile(r"state=(?P<state>[0-9]+)", re.MULTILINE)
-REGEX_WINDOW = re.compile(r"Window\{(?P<id>.+?) (?P<user>.+) (?P<package>.+?)(?:\/(?P<activity>.+?))?\}$", re.MULTILINE)
 
 # Regular expression patterns
 DEVICE_REGEX_PATTERN = r"Devices: (.*?)\W"

--- a/androidtv/constants.py
+++ b/androidtv/constants.py
@@ -199,6 +199,7 @@ APP_HULU = 'com.hulu.plus'
 APP_JELLYFIN_TV = 'org.jellyfin.androidtv'
 APP_KODI = 'org.xbmc.kodi'
 APP_NETFLIX = 'com.netflix.ninja'
+APP_PLEX = 'com.plexapp.android'
 APP_SPORT1 = 'de.sport1.firetv.video'
 APP_SPOTIFY = 'com.spotify.tv.android'
 APP_TWITCH = 'tv.twitch.android.viewer'
@@ -211,6 +212,7 @@ APPS = {APP_AMAZON_VIDEO: 'Amazon Video',
         APP_JELLYFIN_TV: 'Jellyfin',
         APP_KODI: 'Kodi',
         APP_NETFLIX: 'Netflix',
+        APP_PLEX: 'Plex',
         APP_SPORT1: 'Sport 1',
         APP_SPOTIFY: 'Spotify',
         APP_TWITCH: 'Twitch',

--- a/tests/test_androidtv.py
+++ b/tests/test_androidtv.py
@@ -282,8 +282,8 @@ STATE2 = (constants.STATE_IDLE, None, None, None, None)
 
 # `dumpsys power | grep 'Display Power' | grep -q 'state=ON' && echo -e '1\c' && dumpsys power | grep mWakefulness | grep -q Awake && echo -e '1\c' && dumpsys power | grep Locks | grep 'size=' && (dumpsys media_session | grep -m 1 'state=PlaybackState {' || echo) && dumpsys window windows | grep mCurrentFocus && dumpsys audio`
 GET_PROPERTIES_OUTPUT3 = """11Wake Locks: size=2
+com.amazon.tv.launcher
 
-  mCurrentFocus=Window{c82ee5e u0 com.amazon.tv.launcher/com.amazon.tv.launcher.ui.HomeActivity_vNext}
 """ + DUMPSYS_AUDIO_ON
 GET_PROPERTIES_DICT3 = {'screen_on': True,
                         'awake': True,

--- a/tests/test_firetv.py
+++ b/tests/test_firetv.py
@@ -25,7 +25,7 @@ DEVICE_PROPERTIES_DICT = {'manufacturer': 'Amazon',
                           'ethmac': None}
 
 # `adb shell dumpsys window windows | grep mCurrentFocus`
-CURRENT_APP_OUTPUT = "mCurrentFocus=Window{c82ee5e u0 com.amazon.tv.launcher/com.amazon.tv.launcher.ui.HomeActivity_vNext}"
+CURRENT_APP_OUTPUT = "com.amazon.tv.launcher"
 
 # `adb shell dumpsys media_session | grep -m 1 'state=PlaybackState {'`
 MEDIA_SESSION_STATE_OUTPUT = "state=PlaybackState {state=2, position=0, buffered position=0, speed=0.0, updated=65749, actions=240640, custom actions=[], active item id=-1, error=null}"
@@ -58,8 +58,8 @@ STATE2 = (constants.STATE_IDLE, None, None)
 
 # `adb shell dumpsys power | grep 'Display Power' | grep -q 'state=ON' && echo -e '1\c' || echo -e '0\c' && dumpsys power | grep mWakefulness | grep -q Awake && echo -e '1\c' || echo -e '0\c' && dumpsys power | grep Locks | grep 'size=' && (dumpsys media_session | grep -m 1 'state=PlaybackState {' || echo) && dumpsys window windows | grep mCurrentFocus && ps | grep u0_a`
 GET_PROPERTIES_OUTPUT3 = """11Wake Locks: size=2
+com.amazon.tv.launcher
 
-  mCurrentFocus=Window{c82ee5e u0 com.amazon.tv.launcher/com.amazon.tv.launcher.ui.HomeActivity_vNext}
 u0_a2     17243 197   998628 24932 ffffffff 00000000 S com.amazon.device.controllermanager
 u0_a2     17374 197   995368 20764 ffffffff 00000000 S com.amazon.device.controllermanager:BluetoothReceiver"""
 GET_PROPERTIES_DICT3 = {'screen_on': True,


### PR DESCRIPTION
* Improve the command for getting the current app so that it becomes a one-liner with no post-processing needed
* Use the current app to get the correct media session state
* Add state detection for Plex to `AndroidTV`