### PR TITLE
Added VRV app play state detection and related audio state detection changes

### DIFF
--- a/androidtv/androidtv.py
+++ b/androidtv/androidtv.py
@@ -103,6 +103,10 @@ class AndroidTV(BaseTV):
         elif current_app == constants.APP_PLEX:
             state = audio_state
 
+        # VRV
+        elif current_app == constants.APP_VRV:
+            state = audio_state
+
         # TVheadend
         elif current_app == constants.APP_TVHEADEND:
             if wake_lock_size == 5:

--- a/androidtv/androidtv.py
+++ b/androidtv/androidtv.py
@@ -103,10 +103,6 @@ class AndroidTV(BaseTV):
         elif current_app == constants.APP_PLEX:
             state = audio_state
 
-        # VRV
-        elif current_app == constants.APP_VRV:
-            state = audio_state
-
         # TVheadend
         elif current_app == constants.APP_TVHEADEND:
             if wake_lock_size == 5:
@@ -124,6 +120,10 @@ class AndroidTV(BaseTV):
                 state = constants.STATE_PLAYING
             else:
                 state = constants.STATE_STANDBY
+
+        # VRV
+        elif current_app == constants.APP_VRV:
+            state = audio_state
 
         # YouTube
         elif current_app == constants.APP_YOUTUBE:

--- a/androidtv/basetv.py
+++ b/androidtv/basetv.py
@@ -498,7 +498,7 @@ class BaseTV(object):
                 continue
             if 'started' in line:
                 return constants.STATE_PLAYING
-            elif 'paused' in line:
+            if 'paused' in line:
                 return constants.STATE_PAUSED
 
         return constants.STATE_IDLE

--- a/androidtv/basetv.py
+++ b/androidtv/basetv.py
@@ -492,11 +492,14 @@ class BaseTV(object):
         if not dumpsys_audio:
             return None
 
-        if 'started' in dumpsys_audio:
-            return constants.STATE_PLAYING
-
-        if 'paused' in dumpsys_audio:
-            return constants.STATE_PAUSED
+        for line in dumpsys_audio.splitlines():
+            if 'OpenSL ES AudioPlayer (Buffer Queue)' in line:
+                # ignore this line which can cause false positives for some apps (e.g. VRV)
+                continue
+            if 'started' in line:
+                return constants.STATE_PLAYING
+            elif 'paused' in line:
+                return constants.STATE_PAUSED
 
         return constants.STATE_IDLE
 

--- a/androidtv/constants.py
+++ b/androidtv/constants.py
@@ -11,7 +11,7 @@ CMD_SUCCESS1 = r" && echo -e '1\c'"
 CMD_SUCCESS1_FAILURE0 = r" && echo -e '1\c' || echo -e '0\c'"
 
 # ADB shell commands for getting various properties
-CMD_AUDIO_STATE = r"dumpsys audio | grep -q paused && echo -e '1\c' || (dumpsys audio | grep -q started && echo '2\c' || echo '0\c')"
+CMD_AUDIO_STATE = r"dumpsys audio | grep -v 'Buffer Queue' | grep -q paused && echo -e '1\c' || (dumpsys audio | grep -v 'Buffer Queue' | grep -q started && echo '2\c' || echo '0\c')"
 CMD_AWAKE = "dumpsys power | grep mWakefulness | grep -q Awake"
 CMD_CURRENT_APP = "CURRENT_APP=$(dumpsys window windows | grep mCurrentFocus) && CURRENT_APP=${CURRENT_APP#*{* * } && CURRENT_APP=${CURRENT_APP%%/*}"
 CMD_CURRENT_APP_FULL = CMD_CURRENT_APP + " && echo $CURRENT_APP"
@@ -206,6 +206,7 @@ APP_SPOTIFY = 'com.spotify.tv.android'
 APP_TVHEADEND = 'de.cyberdream.dreamepg.tvh.tv.player'
 APP_TWITCH = 'tv.twitch.android.viewer'
 APP_VLC = 'org.videolan.vlc'
+APP_VRV = 'com.ellation.vrv'
 APP_WAIPU_TV = 'de.exaring.waipu.firetv.live'
 APP_YOUTUBE = 'com.google.android.youtube.tv'
 APPS = {APP_AMAZON_VIDEO: 'Amazon Video',
@@ -222,6 +223,7 @@ APPS = {APP_AMAZON_VIDEO: 'Amazon Video',
         APP_TVHEADEND: 'DreamPLayer TVHeadend',
         APP_TWITCH: 'Twitch',
         APP_VLC: 'VLC',
+        APP_VRV: 'VRV',
         APP_WAIPU_TV: 'Waipu TV',
         APP_YOUTUBE: 'Youtube'}
 


### PR DESCRIPTION
During VRV playback, two audio states are available:

Partial output of `dumpsys_media` while VRV is open and paused:
```
  ID:23 -- type:android.media.SoundPool -- u/pid:10031/3848 -- state:idle -- attr:AudioAttributes: usage=13 content=4 flags=0x0 tags= bundle=null
  ID:327 -- type:OpenSL ES AudioPlayer (Buffer Queue) -- u/pid:10107/31690 -- state:started -- attr:AudioAttributes: usage=1 content=0 flags=0x0 tags= bundle=null
  ID:343 -- type:android.media.AudioTrack -- u/pid:10107/31690 -- state:paused -- attr:AudioAttributes: usage=1 content=0 flags=0x200 tags= bundle=null
  ID:15 -- type:android.media.SoundPool -- u/pid:1000/3719 -- state:idle -- attr:AudioAttributes: usage=13 content=4 flags=0x0 tags= bundle=null
```

And while VRV is open and playing:
```
  ID:23 -- type:android.media.SoundPool -- u/pid:10031/3848 -- state:idle -- attr:AudioAttributes: usage=13 content=4 flags=0x0 tags= bundle=null
  ID:327 -- type:OpenSL ES AudioPlayer (Buffer Queue) -- u/pid:10107/31690 -- state:started -- attr:AudioAttributes: usage=1 content=0 flags=0x0 tags= bundle=null
  ID:343 -- type:android.media.AudioTrack -- u/pid:10107/31690 -- state:started -- attr:AudioAttributes: usage=1 content=0 flags=0x200 tags= bundle=null
  ID:15 -- type:android.media.SoundPool -- u/pid:1000/3719 -- state:idle -- attr:AudioAttributes: usage=13 content=4 flags=0x0 tags= bundle=null
```

Needed to add extra code to constants.AUDIO_STATE and basetv._audio_state to ignore the `Buffer Queue` line.