### PR TITLE
Fix 'CMD_ANDROIDTV_PROPERTIES_*' commands

### DIFF
--- a/androidtv/constants.py
+++ b/androidtv/constants.py
@@ -45,10 +45,10 @@ CMD_STREAM_MUSIC = r"dumpsys audio | grep '\- STREAM_MUSIC:' -A 12"
 CMD_WAKE_LOCK_SIZE = "dumpsys power | grep Locks | grep 'size='"
 
 #: Get the properties for an :py:class:`~androidtv.androidtv.AndroidTV` device (``lazy=True``); see :py:meth:`androidtv.androidtv.AndroidTV.get_properties`
-CMD_ANDROIDTV_PROPERTIES_LAZY = CMD_SCREEN_ON + CMD_SUCCESS1 + " && " + CMD_AWAKE + CMD_SUCCESS1 + " && " + CMD_AUDIO_STATE + " && " + CMD_WAKE_LOCK_SIZE + " && " + CMD_CURRENT_APP + " && (" + CMD_MEDIA_SESSION_STATE + " || echo) && " + CMD_STREAM_MUSIC
+CMD_ANDROIDTV_PROPERTIES_LAZY = CMD_SCREEN_ON + CMD_SUCCESS1 + " && " + CMD_AWAKE + CMD_SUCCESS1 + " && (" + CMD_AUDIO_STATE + ") && " + CMD_WAKE_LOCK_SIZE + " && " + CMD_CURRENT_APP + " && (" + CMD_MEDIA_SESSION_STATE + " || echo) && " + CMD_STREAM_MUSIC
 
 #: Get the properties for an :py:class:`~androidtv.androidtv.AndroidTV` device (``lazy=False``); see :py:meth:`androidtv.androidtv.AndroidTV.get_properties`
-CMD_ANDROIDTV_PROPERTIES_NOT_LAZY = CMD_SCREEN_ON + CMD_SUCCESS1_FAILURE0 + " && " + CMD_AWAKE + CMD_SUCCESS1_FAILURE0 + " && " + CMD_AUDIO_STATE + " && " + CMD_WAKE_LOCK_SIZE + " && " + CMD_CURRENT_APP + " && (" + CMD_MEDIA_SESSION_STATE + " || echo) && " + CMD_STREAM_MUSIC
+CMD_ANDROIDTV_PROPERTIES_NOT_LAZY = CMD_SCREEN_ON + CMD_SUCCESS1_FAILURE0 + " && " + CMD_AWAKE + CMD_SUCCESS1_FAILURE0 + " && (" + CMD_AUDIO_STATE + ") && " + CMD_WAKE_LOCK_SIZE + " && " + CMD_CURRENT_APP + " && (" + CMD_MEDIA_SESSION_STATE + " || echo) && " + CMD_STREAM_MUSIC
 
 #: Get the properties for a :py:class:`~androidtv.firetv.FireTV` device (``lazy=True, get_running_apps=True``); see :py:meth:`androidtv.firetv.FireTV.get_properties`
 CMD_FIRETV_PROPERTIES_LAZY_RUNNING_APPS = CMD_SCREEN_ON + CMD_SUCCESS1 + " && " + CMD_AWAKE + CMD_SUCCESS1 + " && " + CMD_WAKE_LOCK_SIZE + " && " + CMD_CURRENT_APP + " && (" + CMD_MEDIA_SESSION_STATE + " || echo) && " + CMD_RUNNING_APPS


### PR DESCRIPTION
```bash
#!/bin/bash

# "dumpsys power | grep 'Display Power' | grep -q 'state=ON' && echo -e '1\\c' && dumpsys power | grep mWakefulness | grep -q Awake && echo -e '1\\c' && dumpsys audio | grep paused | grep -qv 'Buffer Queue' && echo -e '1\\c' || (dumpsys audio | grep started | grep -qv 'Buffer Queue' && echo '2\\c' || echo '0\\c') && dumpsys power | grep Locks | grep 'size=' && CURRENT_APP=$(dumpsys window windows | grep mCurrentFocus) && CURRENT_APP=${CURRENT_APP#*{* * } && CURRENT_APP=${CURRENT_APP%%/*} && echo $CURRENT_APP && (dumpsys media_session | grep -A 100 'Sessions Stack' | grep -A 100 $CURRENT_APP | grep -m 1 'state=PlaybackState {' || echo) && dumpsys audio | grep '\\- STREAM_MUSIC:' -A 12"

#SCREEN_ON="state=ON"
SCREEN_ON="state=OFF"
#AWAKE="Awake"
AWAKE="asleep"
#AUDIO_STATE="paused"
AUDIO_STATE="started"
#AUDIO_STATE=""


echo -e "\nCurrent CMD_ANDROIDTV_PROPERTIES_LAZY"
echo "$SCREEN_ON" | grep -q 'state=ON' && echo -e '1\c' && echo "$AWAKE" | grep -q "Awake" && echo -e '1\c' && echo "$AUDIO_STATE" | grep -q paused && echo -e '1\c' || (echo "$AUDIO_STATE" | grep -q "started" && echo -e '2\c' || echo -e '0\c')
echo

echo -e "\nUpdated CMD_ANDROIDTV_PROPERTIES_LAZY"
echo "$SCREEN_ON" | grep -q 'state=ON' && echo -e '1\c' && echo "$AWAKE" | grep -q "Awake" && echo -e '1\c' && (echo "$AUDIO_STATE" | grep -q paused && echo -e '1\c' || (echo "$AUDIO_STATE" | grep -q "started" && echo -e '2\c' || echo -e '0\c'))
echo
echo
```

## Output

```
Current CMD_ANDROIDTV_PROPERTIES_LAZY
2

Updated CMD_ANDROIDTV_PROPERTIES_LAZY

```