### PR TITLE
Change Plex `wake_lock_size` priority

### DIFF
--- a/androidtv/androidtv.py
+++ b/androidtv/androidtv.py
@@ -117,6 +117,7 @@ class AndroidTV(BaseTV):
                     state = constants.STATE_STANDBY
 
             # Plex
+            elif current_app == constants.APP_PLEX:
                 if media_session_state == 3:
                     if wake_lock_size == 1:
                         state = constants.STATE_PAUSED

--- a/androidtv/androidtv.py
+++ b/androidtv/androidtv.py
@@ -117,11 +117,11 @@ class AndroidTV(BaseTV):
                     state = constants.STATE_STANDBY
 
             # Plex
-            elif current_app == constants.APP_PLEX:
-                if media_session_state == 3 and wake_lock_size == 1:
-                    state = constants.STATE_PAUSED
-                elif media_session_state == 3:
-                    state = constants.STATE_PLAYING
+                if media_session_state == 3:
+                    if wake_lock_size == 1:
+                        state = constants.STATE_PAUSED
+                    else:
+                        state = constants.STATE_PLAYING
                 else:
                     state = constants.STATE_STANDBY
 

--- a/androidtv/androidtv.py
+++ b/androidtv/androidtv.py
@@ -118,7 +118,12 @@ class AndroidTV(BaseTV):
 
             # Plex
             elif current_app == constants.APP_PLEX:
-                state = audio_state
+                if media_session_state == 3 and wake_lock_size == 1:
+                    state = constants.STATE_PAUSED
+                elif media_session_state == 3:
+                    state = constants.STATE_PLAYING
+                else:
+                    state = constants.STATE_STANDBY
 
             # TVheadend
             elif current_app == constants.APP_TVHEADEND:

--- a/androidtv/basetv.py
+++ b/androidtv/basetv.py
@@ -25,8 +25,8 @@ class BaseTV(object):
                                 'com.ellation.vrv': ['audio_state'],
                                 'com.hulu.plus': [{'playing': {'wake_lock_size' : 4}},
                                                   {'paused': {'wake_lock_size': 2}}],
-                                'com.plexapp.android': [{'playing': {'media_session_state': 3, 'wake_lock_size': 3}},
-                                                        {'paused': {'media_session_state': 3, 'wake_lock_size': 1}},
+                                'com.plexapp.android': [{'paused': {'media_session_state': 3, 'wake_lock_size': 1}},
+                                                        {'playing': {'media_session_state': 3}},
                                                         'standby']}
 
     The keys are app IDs, and the values are lists of rules that are evaluated in order.

--- a/tests/test_androidtv.py
+++ b/tests/test_androidtv.py
@@ -919,6 +919,21 @@ class TestAndroidTVPython(unittest.TestCase):
         self.assertUpdate([True, True, constants.STATE_IDLE, 2, constants.APP_PLEX, 4, 'hmdi_arc', False, 30],
                           (constants.STATE_IDLE, constants.APP_PLEX, 'hmdi_arc', False, 0.5))
 
+        self.assertUpdate([True, True, constants.STATE_IDLE, 3, constants.APP_PLEX, 3, 'hmdi_arc', False, 30],
+                          (constants.STATE_PLAYING, constants.APP_PLEX, 'hmdi_arc', False, 0.5))
+
+        self.assertUpdate([True, True, constants.STATE_IDLE, 4, constants.APP_PLEX, 3, 'hmdi_arc', False, 30],
+                          (constants.STATE_PLAYING, constants.APP_PLEX, 'hmdi_arc', False, 0.5))
+
+        self.assertUpdate([True, True, constants.STATE_IDLE, 5, constants.APP_PLEX, 3, 'hmdi_arc', False, 30],
+                          (constants.STATE_PLAYING, constants.APP_PLEX, 'hmdi_arc', False, 0.5))
+
+        self.assertUpdate([True, True, constants.STATE_IDLE, 7, constants.APP_PLEX, 3, 'hmdi_arc', False, 30],
+                          (constants.STATE_PLAYING, constants.APP_PLEX, 'hmdi_arc', False, 0.5))
+
+        self.assertUpdate([True, True, constants.STATE_IDLE, 1, constants.APP_PLEX, 3, 'hmdi_arc', False, 30],
+                          (constants.STATE_PAUSED, constants.APP_PLEX, 'hmdi_arc', False, 0.5))
+
         # TVheadend
         self.assertUpdate([True, True, constants.STATE_IDLE, 5, constants.APP_TVHEADEND, 4, 'hmdi_arc', False, 30],
                           (constants.STATE_PAUSED, constants.APP_TVHEADEND, 'hmdi_arc', False, 0.5))

--- a/tests/test_androidtv.py
+++ b/tests/test_androidtv.py
@@ -917,7 +917,7 @@ class TestAndroidTVPython(unittest.TestCase):
 
         # Plex
         self.assertUpdate([True, True, constants.STATE_IDLE, 2, constants.APP_PLEX, 4, 'hmdi_arc', False, 30],
-                          (constants.STATE_IDLE, constants.APP_PLEX, 'hmdi_arc', False, 0.5))
+                          (constants.STATE_STANDBY, constants.APP_PLEX, 'hmdi_arc', False, 0.5))
 
         self.assertUpdate([True, True, constants.STATE_IDLE, 3, constants.APP_PLEX, 3, 'hmdi_arc', False, 30],
                           (constants.STATE_PLAYING, constants.APP_PLEX, 'hmdi_arc', False, 0.5))


### PR DESCRIPTION
While testing Plex, I found HA was reporting a `standby` state every 15-30 minutes before quickly correcting back to `playing`. This causes my lights to flash on and off which isn't ideal during a movie.

I'm using a 2017 Nvidia Shield device with the [`c6dbc683eb71676baf16ae6125226304d428b889`](https://github.com/JeffLIrion/ha-androidtv/tree/c6dbc683eb71676baf16ae6125226304d428b889) on `ha-androidtv/master`. But this has been going on for a few weeks now. I can't really pinpoint a date though..

I set up the logging to report the states of the Shield every 1 second and managed to capture some extra states that I would consider `playing`, but the code considers standby.

Here are some of those log line snippets. ('wake_lock_size' = `3`, `4`, `5`, and `7`)
All of those `wake_lock_size` were while the device was `playing`. 

```
2019-10-19 20:28:10 INFO (SyncWorker_12) [custom_components.androidtv.media_player] Output of command 'GET_PROPERTIES' from 'media_player.shield': {'screen_on': True, 'awake': True, 'audio_state': 'paused', 'wake_lock_size': 3, 'current_app': 'com.plexapp.android', 'media_session_state': 3, 'device': 'hdmi', 'is_volume_muted': False, 'volume': 15}
2019-10-19 20:28:12 INFO (SyncWorker_32) [custom_components.androidtv.media_player] Output of command 'GET_PROPERTIES' from 'media_player.shield': {'screen_on': True, 'awake': True, 'audio_state': 'paused', 'wake_lock_size': 7, 'current_app': 'com.plexapp.android', 'media_session_state': 3, 'device': 'hdmi', 'is_volume_muted': False, 'volume': 15}
2019-10-19 20:28:12 INFO (SyncWorker_22) [custom_components.androidtv.media_player] Output of command 'GET_PROPERTIES' from 'media_player.shield': {'screen_on': True, 'awake': True, 'audio_state': 'paused', 'wake_lock_size': 4, 'current_app': 'com.plexapp.android', 'media_session_state': 3, 'device': 'hdmi', 'is_volume_muted': False, 'volume': 15}
(...)
2019-10-19 20:45:28 INFO (SyncWorker_7) [custom_components.androidtv.media_player] Output of command 'GET_PROPERTIES' from 'media_player.shield': {'screen_on': True, 'awake': True, 'audio_state': 'paused', 'wake_lock_size': 5, 'current_app': 'com.plexapp.android', 'media_session_state': 3, 'device': 'hdmi', 'is_volume_muted': False, 'volume': 15}
```

Since `paused` only uses a `'wake_lock_size': 1`, it seems appropriate to make that the base case, and then the `if else` case for `media_session_state: 3` will always be `playing` (since we aren't sure if the `wake_lock_size` is _only_ limited to  `3`, `4`, `5`, and `7`).

This PR makes those changes to get plex working again (and removing a bunch of the edge cases I kept experiencing).