### PR TITLE
Fix netflix continue watching to report paused state

### DIFF
--- a/androidtv/androidtv.py
+++ b/androidtv/androidtv.py
@@ -109,7 +109,11 @@ class AndroidTV(BaseTV):
                 if media_session_state == 2:
                     state = constants.STATE_PAUSED
                 elif media_session_state == 3:
-                    state = constants.STATE_PLAYING
+                    if audio_state == 'idle':
+                        # Continue Watching screen to paused
+                        state = constants.STATE_PAUSED
+                    else:
+                        state = constants.STATE_PLAYING
                 else:
                     state = constants.STATE_STANDBY
 


### PR DESCRIPTION
Netflix updated their app sometime around end of December and at the “continue watching” screen, media_session_state stays at value 3 and therefore HA state stays at playing. Before this Netflix update, this would go to media_session_state = 2 and HA would report state paused. 

I used to use this playing to paused state change in an automation for my disabled daughter to catch when her show paused and required us to hit ok to continue watching. 