### PR TITLE
Rename Apple TV+ strings

### DIFF
--- a/androidtv/constants.py
+++ b/androidtv/constants.py
@@ -307,8 +307,8 @@ MEDIA_SESSION_STATES = {0: None,
 APP_AE_TV = 'com.aetn.aetv.watch'
 APP_AMAZON_PRIME_VIDEO = 'com.amazon.avod.thirdpartyclient'
 APP_AMAZON_VIDEO = 'com.amazon.avod'
-APP_APPLE_TV = 'com.apple.atve.sony.appletv'
-APP_APPLE_TV_FIRETV = 'com.apple.atve.amazon.appletv'
+APP_APPLE_TV_PLUS = 'com.apple.atve.sony.appletv'
+APP_APPLE_TV_PLUS_FIRETV = 'com.apple.atve.amazon.appletv'
 APP_ATV_LAUNCHER = 'com.google.android.tvlauncher'
 APP_BELL_FIBE = 'com.quickplay.android.bellmediaplayer'
 APP_COMEDY_CENTRAL = 'com.vmn.android.comedycentral'
@@ -396,8 +396,8 @@ APP_ZIGGO_GO_TV = 'com.ziggo.tv'
 APPS = {APP_AE_TV: 'A&E',
         APP_AMAZON_PRIME_VIDEO: 'Amazon Prime Video',
         APP_AMAZON_VIDEO: 'Amazon Video',
-        APP_APPLE_TV: 'Apple TV',
-        APP_APPLE_TV_FIRETV: 'Apple TV (FireTV)',
+        APP_APPLE_TV_PLUS: 'Apple TV+',
+        APP_APPLE_TV_PLUS_FIRETV: 'Apple TV+',
         APP_ATV_LAUNCHER: 'Android TV Launcher',
         APP_BELL_FIBE: 'Bell Fibe',
         APP_COMEDY_CENTRAL: 'Comedy Central',


### PR DESCRIPTION
Setting the same app name in each of the individual Apple TV+ apps because no two apps can exist at the same time.