### PR TITLE
Add transport_timeout_s parameter for setup and adb_connect methods

### DIFF
--- a/androidtv/__init__.py
+++ b/androidtv/__init__.py
@@ -6,7 +6,7 @@ ADB Debugging must be enabled.
 from .androidtv.androidtv_sync import AndroidTVSync
 from .basetv.basetv import state_detection_rules_validator
 from .basetv.basetv_sync import BaseTVSync
-from .constants import DEFAULT_AUTH_TIMEOUT_S
+from .constants import DEFAULT_AUTH_TIMEOUT_S, DEFAULT_TRANSPORT_TIMEOUT_S
 from .firetv.firetv_sync import FireTVSync
 
 
@@ -23,6 +23,7 @@ def setup(
     device_class="auto",
     auth_timeout_s=DEFAULT_AUTH_TIMEOUT_S,
     signer=None,
+    transport_timeout_s=DEFAULT_TRANSPORT_TIMEOUT_S,
 ):
     """Connect to a device and determine whether it's an Android TV or an Amazon Fire TV.
 
@@ -46,6 +47,8 @@ def setup(
         Authentication timeout (in seconds)
     signer : PythonRSASigner, None
         The signer for the ADB keys, as loaded by :meth:`androidtv.adb_manager.adb_manager_sync.ADBPythonSync.load_adbkey`
+    transport_timeout_s : float
+        Transport timeout (in seconds). Maximum allowed value is 5 seconds
 
     Returns
     -------
@@ -55,14 +58,14 @@ def setup(
     """
     if device_class == "androidtv":
         atv = AndroidTVSync(host, port, adbkey, adb_server_ip, adb_server_port, state_detection_rules, signer)
-        atv.adb_connect(auth_timeout_s=auth_timeout_s)
+        atv.adb_connect(auth_timeout_s=auth_timeout_s, transport_timeout_s=transport_timeout_s)
         atv.get_device_properties()
         atv.get_installed_apps()
         return atv
 
     if device_class == "firetv":
         ftv = FireTVSync(host, port, adbkey, adb_server_ip, adb_server_port, state_detection_rules, signer)
-        ftv.adb_connect(auth_timeout_s=auth_timeout_s)
+        ftv.adb_connect(auth_timeout_s=auth_timeout_s, transport_timeout_s=transport_timeout_s)
         ftv.get_device_properties()
         ftv.get_installed_apps()
         return ftv
@@ -73,7 +76,7 @@ def setup(
     aftv = BaseTVSync(host, port, adbkey, adb_server_ip, adb_server_port, state_detection_rules, signer)
 
     # establish the ADB connection
-    aftv.adb_connect(auth_timeout_s=auth_timeout_s)
+    aftv.adb_connect(auth_timeout_s=auth_timeout_s, transport_timeout_s=transport_timeout_s)
 
     # get device properties
     aftv.device_properties = aftv.get_device_properties()

--- a/androidtv/__init__.py
+++ b/androidtv/__init__.py
@@ -48,7 +48,7 @@ def setup(
     signer : PythonRSASigner, None
         The signer for the ADB keys, as loaded by :meth:`androidtv.adb_manager.adb_manager_sync.ADBPythonSync.load_adbkey`
     transport_timeout_s : float
-        Transport timeout (in seconds). Maximum allowed value is 5 seconds
+        Transport timeout (in seconds)
 
     Returns
     -------

--- a/androidtv/adb_manager/adb_manager_async.py
+++ b/androidtv/adb_manager/adb_manager_async.py
@@ -22,7 +22,6 @@ from ..constants import (
     DEFAULT_AUTH_TIMEOUT_S,
     DEFAULT_LOCK_TIMEOUT_S,
     DEFAULT_TRANSPORT_TIMEOUT_S,
-    MAX_TRANSPORT_TIMEOUT_S,
 )
 from ..exceptions import LockNotAcquiredException
 
@@ -245,7 +244,7 @@ class ADBPythonAsync(object):
         auth_timeout_s : float
             Authentication timeout (in seconds)
         transport_timeout_s : float
-            Transport timeout (in seconds). Maximum allowed value is 5 seconds
+            Transport timeout (in seconds)
 
         Returns
         -------
@@ -264,16 +263,13 @@ class ADBPythonAsync(object):
 
                         await self._adb.connect(
                             rsa_keys=[self._signer],
-                            transport_timeout_s=min(transport_timeout_s, MAX_TRANSPORT_TIMEOUT_S),
+                            transport_timeout_s=transport_timeout_s,
                             auth_timeout_s=auth_timeout_s,
                         )
 
                     # Connect without authentication
                     else:
-                        await self._adb.connect(
-                            transport_timeout_s=min(transport_timeout_s, MAX_TRANSPORT_TIMEOUT_S),
-                            auth_timeout_s=auth_timeout_s,
-                        )
+                        await self._adb.connect(transport_timeout_s=transport_timeout_s, auth_timeout_s=auth_timeout_s)
 
                     # ADB connection successfully established
                     _LOGGER.debug("ADB connection to %s:%d successfully established", self.host, self.port)

--- a/androidtv/adb_manager/adb_manager_async.py
+++ b/androidtv/adb_manager/adb_manager_async.py
@@ -272,7 +272,7 @@ class ADBPythonAsync(object):
                     else:
                         await self._adb.connect(
                             transport_timeout_s=min(transport_timeout_s, MAX_TRANSPORT_TIMEOUT_S),
-                            auth_timeout_s=auth_timeout_s
+                            auth_timeout_s=auth_timeout_s,
                         )
 
                     # ADB connection successfully established

--- a/androidtv/adb_manager/adb_manager_sync.py
+++ b/androidtv/adb_manager/adb_manager_sync.py
@@ -156,7 +156,7 @@ class ADBPythonSync(object):
                     else:
                         self._adb.connect(
                             transport_timeout_s=min(transport_timeout_s, MAX_TRANSPORT_TIMEOUT_S),
-                            auth_timeout_s=auth_timeout_s
+                            auth_timeout_s=auth_timeout_s,
                         )
 
                     # ADB connection successfully established

--- a/androidtv/adb_manager/adb_manager_sync.py
+++ b/androidtv/adb_manager/adb_manager_sync.py
@@ -20,7 +20,6 @@ from ..constants import (
     DEFAULT_AUTH_TIMEOUT_S,
     DEFAULT_LOCK_TIMEOUT_S,
     DEFAULT_TRANSPORT_TIMEOUT_S,
-    MAX_TRANSPORT_TIMEOUT_S,
 )
 from ..exceptions import LockNotAcquiredException
 
@@ -129,7 +128,7 @@ class ADBPythonSync(object):
         auth_timeout_s : float
             Authentication timeout (in seconds)
         transport_timeout_s : float
-            Transport timeout (in seconds). Maximum allowed value is 5 seconds
+            Transport timeout (in seconds)
 
         Returns
         -------
@@ -148,16 +147,13 @@ class ADBPythonSync(object):
 
                         self._adb.connect(
                             rsa_keys=[self._signer],
-                            transport_timeout_s=min(transport_timeout_s, MAX_TRANSPORT_TIMEOUT_S),
+                            transport_timeout_s=transport_timeout_s,
                             auth_timeout_s=auth_timeout_s,
                         )
 
                     # Connect without authentication
                     else:
-                        self._adb.connect(
-                            transport_timeout_s=min(transport_timeout_s, MAX_TRANSPORT_TIMEOUT_S),
-                            auth_timeout_s=auth_timeout_s,
-                        )
+                        self._adb.connect(transport_timeout_s=transport_timeout_s, auth_timeout_s=auth_timeout_s)
 
                     # ADB connection successfully established
                     _LOGGER.debug("ADB connection to %s:%d successfully established", self.host, self.port)

--- a/androidtv/basetv/basetv_async.py
+++ b/androidtv/basetv/basetv_async.py
@@ -172,7 +172,7 @@ class BaseTVAsync(BaseTV):
         auth_timeout_s : float
             Authentication timeout (in seconds)
         transport_timeout_s : float
-            Transport timeout (in seconds). Maximum allowed value is 5 seconds
+            Transport timeout (in seconds)
 
         Returns
         -------

--- a/androidtv/basetv/basetv_async.py
+++ b/androidtv/basetv/basetv_async.py
@@ -157,7 +157,12 @@ class BaseTVAsync(BaseTV):
         """
         return await self._adb.screencap()
 
-    async def adb_connect(self, always_log_errors=True, auth_timeout_s=constants.DEFAULT_AUTH_TIMEOUT_S):
+    async def adb_connect(
+        self,
+        always_log_errors=True,
+        auth_timeout_s=constants.DEFAULT_AUTH_TIMEOUT_S,
+        transport_timeout_s=constants.DEFAULT_TRANSPORT_TIMEOUT_S,
+    ):
         """Connect to an Android TV / Fire TV device.
 
         Parameters
@@ -166,6 +171,8 @@ class BaseTVAsync(BaseTV):
             If True, errors will always be logged; otherwise, errors will only be logged on the first failed reconnect attempt
         auth_timeout_s : float
             Authentication timeout (in seconds)
+        transport_timeout_s : float
+            Transport timeout (in seconds). Maximum allowed value is 5 seconds
 
         Returns
         -------
@@ -174,7 +181,7 @@ class BaseTVAsync(BaseTV):
 
         """
         if isinstance(self._adb, ADBPythonAsync):
-            return await self._adb.connect(always_log_errors, auth_timeout_s)
+            return await self._adb.connect(always_log_errors, auth_timeout_s, transport_timeout_s)
         return await self._adb.connect(always_log_errors)
 
     async def adb_close(self):

--- a/androidtv/basetv/basetv_sync.py
+++ b/androidtv/basetv/basetv_sync.py
@@ -172,7 +172,7 @@ class BaseTVSync(BaseTV):
         auth_timeout_s : float
             Authentication timeout (in seconds)
         transport_timeout_s : float
-            Transport timeout (in seconds). Maximum allowed value is 5 seconds
+            Transport timeout (in seconds)
 
         Returns
         -------

--- a/androidtv/basetv/basetv_sync.py
+++ b/androidtv/basetv/basetv_sync.py
@@ -157,7 +157,12 @@ class BaseTVSync(BaseTV):
         """
         return self._adb.screencap()
 
-    def adb_connect(self, always_log_errors=True, auth_timeout_s=constants.DEFAULT_AUTH_TIMEOUT_S):
+    def adb_connect(
+        self,
+        always_log_errors=True,
+        auth_timeout_s=constants.DEFAULT_AUTH_TIMEOUT_S,
+        transport_timeout_s=constants.DEFAULT_TRANSPORT_TIMEOUT_S,
+    ):
         """Connect to an Android TV / Fire TV device.
 
         Parameters
@@ -166,6 +171,8 @@ class BaseTVSync(BaseTV):
             If True, errors will always be logged; otherwise, errors will only be logged on the first failed reconnect attempt
         auth_timeout_s : float
             Authentication timeout (in seconds)
+        transport_timeout_s : float
+            Transport timeout (in seconds). Maximum allowed value is 5 seconds
 
         Returns
         -------
@@ -174,7 +181,7 @@ class BaseTVSync(BaseTV):
 
         """
         if isinstance(self._adb, ADBPythonSync):
-            return self._adb.connect(always_log_errors, auth_timeout_s)
+            return self._adb.connect(always_log_errors, auth_timeout_s, transport_timeout_s)
         return self._adb.connect(always_log_errors)
 
     def adb_close(self):

--- a/androidtv/constants.py
+++ b/androidtv/constants.py
@@ -564,6 +564,12 @@ VOLUME_REGEX_PATTERN = r"\): (\d{1,})"
 #: Default authentication timeout (in s) for :meth:`adb_shell.handle.tcp_handle.TcpHandle.connect` and :meth:`adb_shell.handle.tcp_handle_async.TcpHandleAsync.connect`
 DEFAULT_AUTH_TIMEOUT_S = 10.0
 
+#: Default transport timeout (in s) for :meth:`adb_shell.handle.tcp_handle.TcpHandle.connect` and :meth:`adb_shell.handle.tcp_handle_async.TcpHandleAsync.connect`
+DEFAULT_TRANSPORT_TIMEOUT_S = 1.0
+
+#: Maximum allowed transport timeout (in s) for :meth:`adb_shell.handle.tcp_handle.TcpHandle.connect` and :meth:`adb_shell.handle.tcp_handle_async.TcpHandleAsync.connect`
+MAX_TRANSPORT_TIMEOUT_S = 5.0
+
 #: Default timeout (in s) for :class:`adb_shell.handle.tcp_handle.TcpHandle` and :class:`adb_shell.handle.tcp_handle_async.TcpHandleAsync`
 DEFAULT_ADB_TIMEOUT_S = 9.0
 

--- a/androidtv/constants.py
+++ b/androidtv/constants.py
@@ -567,9 +567,6 @@ DEFAULT_AUTH_TIMEOUT_S = 10.0
 #: Default transport timeout (in s) for :meth:`adb_shell.handle.tcp_handle.TcpHandle.connect` and :meth:`adb_shell.handle.tcp_handle_async.TcpHandleAsync.connect`
 DEFAULT_TRANSPORT_TIMEOUT_S = 1.0
 
-#: Maximum allowed transport timeout (in s) for :meth:`adb_shell.handle.tcp_handle.TcpHandle.connect` and :meth:`adb_shell.handle.tcp_handle_async.TcpHandleAsync.connect`
-MAX_TRANSPORT_TIMEOUT_S = 5.0
-
 #: Default timeout (in s) for :class:`adb_shell.handle.tcp_handle.TcpHandle` and :class:`adb_shell.handle.tcp_handle_async.TcpHandleAsync`
 DEFAULT_ADB_TIMEOUT_S = 9.0
 

--- a/androidtv/setup_async.py
+++ b/androidtv/setup_async.py
@@ -5,7 +5,7 @@ ADB Debugging must be enabled.
 
 from .androidtv.androidtv_async import AndroidTVAsync
 from .basetv.basetv_async import BaseTVAsync
-from .constants import DEFAULT_AUTH_TIMEOUT_S
+from .constants import DEFAULT_AUTH_TIMEOUT_S, DEFAULT_TRANSPORT_TIMEOUT_S
 from .firetv.firetv_async import FireTVAsync
 
 
@@ -19,6 +19,7 @@ async def setup(
     device_class="auto",
     auth_timeout_s=DEFAULT_AUTH_TIMEOUT_S,
     signer=None,
+    transport_timeout_s=DEFAULT_TRANSPORT_TIMEOUT_S,
 ):
     """Connect to a device and determine whether it's an Android TV or an Amazon Fire TV.
 
@@ -42,6 +43,8 @@ async def setup(
         Authentication timeout (in seconds)
     signer : PythonRSASigner, None
         The signer for the ADB keys, as loaded by :meth:`androidtv.adb_manager.adb_manager_async.ADBPythonAsync.load_adbkey`
+    transport_timeout_s : float
+        Transport timeout (in seconds). Maximum allowed value is 5 seconds
 
     Returns
     -------
@@ -51,14 +54,14 @@ async def setup(
     """
     if device_class == "androidtv":
         atv = AndroidTVAsync(host, port, adbkey, adb_server_ip, adb_server_port, state_detection_rules, signer)
-        await atv.adb_connect(auth_timeout_s=auth_timeout_s)
+        await atv.adb_connect(auth_timeout_s=auth_timeout_s, transport_timeout_s=transport_timeout_s)
         await atv.get_device_properties()
         await atv.get_installed_apps()
         return atv
 
     if device_class == "firetv":
         ftv = FireTVAsync(host, port, adbkey, adb_server_ip, adb_server_port, state_detection_rules, signer)
-        await ftv.adb_connect(auth_timeout_s=auth_timeout_s)
+        await ftv.adb_connect(auth_timeout_s=auth_timeout_s, transport_timeout_s=transport_timeout_s)
         await ftv.get_device_properties()
         await ftv.get_installed_apps()
         return ftv
@@ -69,7 +72,7 @@ async def setup(
     aftv = BaseTVAsync(host, port, adbkey, adb_server_ip, adb_server_port, state_detection_rules, signer)
 
     # establish the ADB connection
-    await aftv.adb_connect(auth_timeout_s=auth_timeout_s)
+    await aftv.adb_connect(auth_timeout_s=auth_timeout_s, transport_timeout_s=transport_timeout_s)
 
     # get device properties
     await aftv.get_device_properties()

--- a/androidtv/setup_async.py
+++ b/androidtv/setup_async.py
@@ -44,7 +44,7 @@ async def setup(
     signer : PythonRSASigner, None
         The signer for the ADB keys, as loaded by :meth:`androidtv.adb_manager.adb_manager_async.ADBPythonAsync.load_adbkey`
     transport_timeout_s : float
-        Transport timeout (in seconds). Maximum allowed value is 5 seconds
+        Transport timeout (in seconds)
 
     Returns
     -------


### PR DESCRIPTION
In most case during initial connection to my FireTV devices I receive back the error:

```
[androidtv.adb_manager.adb_manager_async] Couldn't connect to 192.168.10.18:5555.  TcpTimeoutException: Connecting to 192.168.10.18:5555 timed out (1.0 seconds)
```

With this PR it will be possible to increase a little bit the `transport_timeout` used in the `connect` method that is currently hard coded to 1 second.