### PR TITLE
Fix for current application in android 11

### DIFF
--- a/androidtv/constants.py
+++ b/androidtv/constants.py
@@ -96,7 +96,7 @@ CMD_DEFINE_CURRENT_APP_VARIABLE = (
 )
 #: Assign focused application identifier to ``CURRENT_APP`` variable for an Android 11 device
 CMD_DEFINE_CURRENT_APP_VARIABLE11 = (
-    "CURRENT_APP=$(dumpsys window windows | grep 'Window #1') && " + CMD_PARSE_CURRENT_APP11
+    "CURRENT_APP=$(dumpsys window windows | grep 'mInputMethodTarget') && " + CMD_PARSE_CURRENT_APP11
 )
 
 

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -86,7 +86,7 @@ class TestConstants(unittest.TestCase):
         # CMD_CURRENT_APP11
         self.assertCommand(
             constants.CMD_CURRENT_APP11,
-            r"CURRENT_APP=$(dumpsys window windows | grep 'Window #1') && CURRENT_APP=${CURRENT_APP%%/*} && CURRENT_APP=${CURRENT_APP##* } && echo $CURRENT_APP",
+            r"CURRENT_APP=$(dumpsys window windows | grep 'mInputMethodTarget') && CURRENT_APP=${CURRENT_APP%%/*} && CURRENT_APP=${CURRENT_APP##* } && echo $CURRENT_APP",
         )
 
         # CMD_CURRENT_APP_GOOGLE_TV
@@ -104,7 +104,7 @@ class TestConstants(unittest.TestCase):
         # CMD_CURRENT_APP_MEDIA_SESSION_STATE11
         self.assertCommand(
             constants.CMD_CURRENT_APP_MEDIA_SESSION_STATE11,
-            r"CURRENT_APP=$(dumpsys window windows | grep 'Window #1') && CURRENT_APP=${CURRENT_APP%%/*} && CURRENT_APP=${CURRENT_APP##* } && echo $CURRENT_APP && dumpsys media_session | grep -A 100 'Sessions Stack' | grep -A 100 $CURRENT_APP | grep -m 1 'state=PlaybackState {'",
+            r"CURRENT_APP=$(dumpsys window windows | grep 'mInputMethodTarget') && CURRENT_APP=${CURRENT_APP%%/*} && CURRENT_APP=${CURRENT_APP##* } && echo $CURRENT_APP && dumpsys media_session | grep -A 100 'Sessions Stack' | grep -A 100 $CURRENT_APP | grep -m 1 'state=PlaybackState {'",
         )
 
         # CMD_CURRENT_APP_MEDIA_SESSION_STATE_GOOGLE_TV
@@ -143,7 +143,7 @@ class TestConstants(unittest.TestCase):
         # CMD_LAUNCH_APP11
         self.assertCommand(
             constants.CMD_LAUNCH_APP11,
-            r"CURRENT_APP=$(dumpsys window windows | grep 'Window #1') && CURRENT_APP=${{CURRENT_APP%%/*}} && CURRENT_APP=${{CURRENT_APP##* }} && if [ $CURRENT_APP != '{0}' ]; then monkey -p {0} -c android.intent.category.LEANBACK_LAUNCHER --pct-syskeys 0 1; fi",
+            r"CURRENT_APP=$(dumpsys window windows | grep 'mInputMethodTarget') && CURRENT_APP=${{CURRENT_APP%%/*}} && CURRENT_APP=${{CURRENT_APP##* }} && if [ $CURRENT_APP != '{0}' ]; then monkey -p {0} -c android.intent.category.LEANBACK_LAUNCHER --pct-syskeys 0 1; fi",
         )
 
         # CMD_LAUNCH_APP_FIRETV


### PR DESCRIPTION
Parsing of current app is broken incase google assitant gets triggered and closed again. Suddenly we have Windows #1 as `mOwnerUid=10050 showForAllUsers=false package=com.google.android.inputmethod.latin appop=NONE` this is not correct.

In this pull request based on the link issue, I've moved the command to find the windows that has the inputfocus instead

See: https://github.com/home-assistant/core/issues/69723