### PR TITLE
Retry power command on error

### DIFF
--- a/androidtv/basetv/basetv_async.py
+++ b/androidtv/basetv/basetv_async.py
@@ -380,7 +380,7 @@ class BaseTVAsync(BaseTV):
         # Power service might sometimes reply with "Failed to write while dumping service". If this happens,
         # retry the request, up to three times.
         retries_left = 3
-        while "Failed to write while dumping service" in output and retries_left > 0:
+        while output is not None and "Failed to write while dumping service" in output and retries_left > 0:
             output = await self._adb.shell(constants.CMD_SCREEN_ON_AWAKE_WAKE_LOCK_SIZE)
             retries_left -= 1
 

--- a/androidtv/basetv/basetv_async.py
+++ b/androidtv/basetv/basetv_async.py
@@ -377,6 +377,13 @@ class BaseTVAsync(BaseTV):
         """
         output = await self._adb.shell(constants.CMD_SCREEN_ON_AWAKE_WAKE_LOCK_SIZE)
 
+        # Power service might sometimes reply with "Failed to write while dumping service". If this happens,
+        # retry the request, up to three times.
+        retries_left = 3
+        while "Failed to write while dumping service" in output and retries_left > 0:
+            output = await self._adb.shell(constants.CMD_SCREEN_ON_AWAKE_WAKE_LOCK_SIZE)
+            retries_left -= 1
+
         return self._screen_on_awake_wake_lock_size(output)
 
     async def stream_music_properties(self):

--- a/androidtv/basetv/basetv_sync.py
+++ b/androidtv/basetv/basetv_sync.py
@@ -377,6 +377,13 @@ class BaseTVSync(BaseTV):
         """
         output = self._adb.shell(constants.CMD_SCREEN_ON_AWAKE_WAKE_LOCK_SIZE)
 
+        # Power service might sometimes reply with "Failed to write while dumping service". If this happens,
+        # retry the request, up to three times.
+        retries_left = 3
+        while output is not None and "Failed to write while dumping service" in output and retries_left > 0:
+            output = self._adb.shell(constants.CMD_SCREEN_ON_AWAKE_WAKE_LOCK_SIZE)
+            retries_left -= 1
+
         return self._screen_on_awake_wake_lock_size(output)
 
     def stream_music_properties(self):

--- a/tests/async_patchers.py
+++ b/tests/async_patchers.py
@@ -124,10 +124,21 @@ def patch_connect(success):
 def patch_shell(response=None, error=False):
     """Mock the `AdbDeviceTcpAsyncFake.shell` and `DeviceAsyncFake.shell` methods."""
 
+    if isinstance(response, list):
+        response_list = response
+    else:
+        response_list = [response]
+
+    next_response = 0
+
     async def shell_success(self, cmd, *args, **kwargs):
         """Mock the `AdbDeviceTcpAsyncFake.shell` and `DeviceAsyncFake.shell` methods when they are successful."""
         self.shell_cmd = cmd
-        return response
+        nonlocal next_response
+        nonlocal response_list
+        res = response_list[next_response]
+        next_response = (next_response + 1) % len(response_list)
+        return res
 
     async def shell_fail_python(self, cmd, *args, **kwargs):
         """Mock the `AdbDeviceTcpAsyncFake.shell` method when it fails."""

--- a/tests/patchers.py
+++ b/tests/patchers.py
@@ -116,10 +116,21 @@ def patch_connect(success):
 def patch_shell(response=None, error=False):
     """Mock the `AdbDeviceTcpFake.shell` and `DeviceFake.shell` methods."""
 
+    if isinstance(response, list):
+        response_list = response
+    else:
+        response_list = [response]
+
+    next_response = 0
+
     def shell_success(self, cmd, *args, **kwargs):
         """Mock the `AdbDeviceTcpFake.shell` and `DeviceFake.shell` methods when they are successful."""
         self.shell_cmd = cmd
-        return response
+        nonlocal next_response
+        nonlocal response_list
+        res = response_list[next_response]
+        next_response = (next_response + 1) % len(response_list)
+        return res
 
     def shell_fail_python(self, cmd, *args, **kwargs):
         """Mock the `AdbDeviceTcpFake.shell` method when it fails."""

--- a/tests/test_basetv_async.py
+++ b/tests/test_basetv_async.py
@@ -421,7 +421,9 @@ class TestBaseTVAsyncPython(unittest.TestCase):
         with async_patchers.patch_shell("11Wake Locks: size=2")[self.PATCH_KEY]:
             self.assertTupleEqual(await self.btv.screen_on_awake_wake_lock_size(), (True, True, 2))
 
-        with async_patchers.patch_shell(["Failed to write while dumping serviceWake Locks: size=2", "11Wake Locks: size=2"])[self.PATCH_KEY]:
+        with async_patchers.patch_shell(
+            ["Failed to write while dumping serviceWake Locks: size=2", "11Wake Locks: size=2"]
+        )[self.PATCH_KEY]:
             self.assertTupleEqual(await self.btv.screen_on_awake_wake_lock_size(), (True, True, 2))
 
     @awaiter

--- a/tests/test_basetv_async.py
+++ b/tests/test_basetv_async.py
@@ -421,6 +421,9 @@ class TestBaseTVAsyncPython(unittest.TestCase):
         with async_patchers.patch_shell("11Wake Locks: size=2")[self.PATCH_KEY]:
             self.assertTupleEqual(await self.btv.screen_on_awake_wake_lock_size(), (True, True, 2))
 
+        with async_patchers.patch_shell(["Failed to write while dumping serviceWake Locks: size=2", "11Wake Locks: size=2"])[self.PATCH_KEY]:
+            self.assertTupleEqual(await self.btv.screen_on_awake_wake_lock_size(), (True, True, 2))
+
     @awaiter
     async def test_wake_lock_size(self):
         """Check that the ``wake_lock_size`` property works correctly."""

--- a/tests/test_basetv_sync.py
+++ b/tests/test_basetv_sync.py
@@ -632,7 +632,9 @@ class TestBaseTVSyncPython(unittest.TestCase):
         with patchers.patch_shell("11Wake Locks: size=2")[self.PATCH_KEY]:
             self.assertTupleEqual(self.btv.screen_on_awake_wake_lock_size(), (True, True, 2))
 
-        with patchers.patch_shell(["Failed to write while dumping serviceWake Locks: size=2", "11Wake Locks: size=2"])[self.PATCH_KEY]:
+        with patchers.patch_shell(["Failed to write while dumping serviceWake Locks: size=2", "11Wake Locks: size=2"])[
+            self.PATCH_KEY
+        ]:
             self.assertTupleEqual(self.btv.screen_on_awake_wake_lock_size(), (True, True, 2))
 
     def test_state_detection_rules_validator(self):

--- a/tests/test_basetv_sync.py
+++ b/tests/test_basetv_sync.py
@@ -632,6 +632,9 @@ class TestBaseTVSyncPython(unittest.TestCase):
         with patchers.patch_shell("11Wake Locks: size=2")[self.PATCH_KEY]:
             self.assertTupleEqual(self.btv.screen_on_awake_wake_lock_size(), (True, True, 2))
 
+        with patchers.patch_shell(["Failed to write while dumping serviceWake Locks: size=2", "11Wake Locks: size=2"])[self.PATCH_KEY]:
+            self.assertTupleEqual(self.btv.screen_on_awake_wake_lock_size(), (True, True, 2))
+
     def test_state_detection_rules_validator(self):
         """Check that the ``state_detection_rules_validator`` function works correctly."""
         with patchers.patch_connect(True)["python"], patchers.patch_shell("")["python"]:


### PR DESCRIPTION
On Nvidia Shield, power service can sometimes reply with "Failed to write while dumping service". When this happens, power state will be output as `None`, even when device is turned on. This can cause Home Assistant to randomly switch playing -> standby -> playing momentarily.

As a workaround, this PR attempts to detect the error and re-send the command when it happens.