### PR TITLE
add support for RTL PLUS (formerly TVNOW)

### DIFF
--- a/androidtv/constants.py
+++ b/androidtv/constants.py
@@ -577,7 +577,7 @@ APPS = {
     APP_TED: "TED",
     APP_TUNEIN: "TuneIn Radio",
     APP_TVHEADEND: "DreamPlayer TVHeadend",
-    APP_TVNOW: "TV NOW",
+    APP_TVNOW: "RTL Plus",
     APP_TWITCH: "Twitch",
     APP_TWITCH_FIRETV: "Twitch (FireTV)",
     APP_VEVO: "Vevo",

--- a/androidtv/constants.py
+++ b/androidtv/constants.py
@@ -474,6 +474,7 @@ APP_T2 = "tv.perception.clients.tv.android"
 APP_TED = "com.ted.android.tv"
 APP_TUNEIN = "tunein.player"
 APP_TVHEADEND = "de.cyberdream.dreamepg.tvh.tv.player"
+APP_TVNOW = "de.cbc.tvnow.firetv"
 APP_TWITCH = "tv.twitch.android.app"
 APP_TWITCH_FIRETV = "tv.twitch.android.viewer"
 APP_VEVO = "com.vevo.tv"
@@ -576,6 +577,7 @@ APPS = {
     APP_TED: "TED",
     APP_TUNEIN: "TuneIn Radio",
     APP_TVHEADEND: "DreamPlayer TVHeadend",
+    APP_TVNOW: "TV NOW",
     APP_TWITCH: "Twitch",
     APP_TWITCH_FIRETV: "Twitch (FireTV)",
     APP_VEVO: "Vevo",

--- a/androidtv/firetv/base_firetv.py
+++ b/androidtv/firetv/base_firetv.py
@@ -178,7 +178,7 @@ class BaseFireTV(BaseTV):  # pylint: disable=too-few-public-methods
                 else:
                     state = constants.STATE_IDLE
 
-            # TV NOW (Germany)
+            # RTL Plus (Germany)
             elif current_app == constants.APP_TVNOW:
                 if wake_lock_size == 3:
                     state = constants.STATE_PAUSED

--- a/androidtv/firetv/base_firetv.py
+++ b/androidtv/firetv/base_firetv.py
@@ -177,6 +177,17 @@ class BaseFireTV(BaseTV):  # pylint: disable=too-few-public-methods
                     state = constants.STATE_PLAYING
                 else:
                     state = constants.STATE_IDLE
+            
+            # TV NOW (Germany)
+            elif current_app == constants.APP_TV_NOW:
+                if wake_lock_size == 3:
+                    state = constants.STATE_PAUSED
+                elif wake_lock_size == 4:
+                    state = constants.STATE_PLAYING
+                elif wake_lock_size == 5:
+                    state = constants.STATE_PLAYING
+                else:
+                    state = constants.STATE_IDLE
 
             # Twitch
             elif current_app == constants.APP_TWITCH_FIRETV:

--- a/androidtv/firetv/base_firetv.py
+++ b/androidtv/firetv/base_firetv.py
@@ -177,9 +177,9 @@ class BaseFireTV(BaseTV):  # pylint: disable=too-few-public-methods
                     state = constants.STATE_PLAYING
                 else:
                     state = constants.STATE_IDLE
-            
+
             # TV NOW (Germany)
-            elif current_app == constants.APP_TV_NOW:
+            elif current_app == constants.APP_TVNOW:
                 if wake_lock_size == 3:
                     state = constants.STATE_PAUSED
                 elif wake_lock_size == 4:

--- a/tests/test_firetv_sync.py
+++ b/tests/test_firetv_sync.py
@@ -328,23 +328,23 @@ class TestFireTVSyncPython(unittest.TestCase):
 
         # TV NOW (Germany)
         self.assertUpdate(
-            [True, True, 1, constants.APP_TV_NOW, 3, [constants.APP_TV_NOW], None],
-            (constants.STATE_PAUSED, constants.APP_TV_NOW, [constants.APP_TV_NOW], None),
+            [True, True, 1, constants.APP_TVNOW, 3, [constants.APP_TVNOW], None],
+            (constants.STATE_PAUSED, constants.APP_TVNOW, [constants.APP_TVNOW], None),
         )
 
         self.assertUpdate(
-            [True, True, 1, constants.APP_TV_NOW, 4, [constants.APP_TV_NOW], None],
-            (constants.STATE_PLAYING, constants.APP_TV_NOW, [constants.APP_TV_NOW], None),
+            [True, True, 1, constants.APP_TVNOW, 4, [constants.APP_TVNOW], None],
+            (constants.STATE_PLAYING, constants.APP_TVNOW, [constants.APP_TVNOW], None),
         )
 
         self.assertUpdate(
-            [True, True, 1, constants.APP_TV_NOW, 5, [constants.APP_TV_NOW], None],
-            (constants.STATE_PLAYING, constants.APP_TV_NOW, [constants.APP_TV_NOW], None),
+            [True, True, 1, constants.APP_TVNOW, 5, [constants.APP_TVNOW], None],
+            (constants.STATE_PLAYING, constants.APP_TVNOW, [constants.APP_TVNOW], None),
         )
 
         self.assertUpdate(
-            [True, True, 1, constants.APP_TV_NOW, 6, [constants.APP_TV_NOW], None],
-            (constants.STATE_IDLE, constants.APP_TV_NOW, [constants.APP_TV_NOW], None),
+            [True, True, 1, constants.APP_TVNOW, 6, [constants.APP_TVNOW], None],
+            (constants.STATE_IDLE, constants.APP_TVNOW, [constants.APP_TVNOW], None),
         )
 
         # Twitch

--- a/tests/test_firetv_sync.py
+++ b/tests/test_firetv_sync.py
@@ -326,6 +326,27 @@ class TestFireTVSyncPython(unittest.TestCase):
             (constants.STATE_IDLE, constants.APP_SPOTIFY, [constants.APP_SPOTIFY], None),
         )
 
+        # TV NOW (Germany)
+        self.assertUpdate(
+            [True, True, 1, constants.APP_TV_NOW, 3, [constants.APP_TV_NOW], None],
+            (constants.STATE_PAUSED, constants.APP_TV_NOW, [constants.APP_TV_NOW], None)
+        )
+
+        self.assertUpdate(
+            [True, True, 1, constants.APP_TV_NOW, 4, [constants.APP_TV_NOW], None],
+            (constants.STATE_PLAYING, constants.APP_TV_NOW, [constants.APP_TV_NOW], None)
+        )
+
+        self.assertUpdate(
+            [True, True, 1, constants.APP_TV_NOW, 5, [constants.APP_TV_NOW], None],
+            (constants.STATE_PLAYING, constants.APP_TV_NOW, [constants.APP_TV_NOW], None)
+        )
+
+        self.assertUpdate(
+            [True, True, 1, constants.APP_TV_NOW, 6, [constants.APP_TV_NOW], None],
+            (constants.STATE_IDLE, constants.APP_TV_NOW, [constants.APP_TV_NOW], None)
+        )
+
         # Twitch
         self.assertUpdate(
             [True, True, 2, constants.APP_TWITCH_FIRETV, 3, [constants.APP_TWITCH_FIRETV], None],

--- a/tests/test_firetv_sync.py
+++ b/tests/test_firetv_sync.py
@@ -326,7 +326,7 @@ class TestFireTVSyncPython(unittest.TestCase):
             (constants.STATE_IDLE, constants.APP_SPOTIFY, [constants.APP_SPOTIFY], None),
         )
 
-        # TV NOW (Germany)
+        # RTL Plus (Germany)
         self.assertUpdate(
             [True, True, 3, constants.APP_TVNOW, 1, [constants.APP_TVNOW], None],
             (constants.STATE_PAUSED, constants.APP_TVNOW, [constants.APP_TVNOW], None),

--- a/tests/test_firetv_sync.py
+++ b/tests/test_firetv_sync.py
@@ -328,22 +328,22 @@ class TestFireTVSyncPython(unittest.TestCase):
 
         # TV NOW (Germany)
         self.assertUpdate(
-            [True, True, 1, constants.APP_TVNOW, 3, [constants.APP_TVNOW], None],
+            [True, True, 3, constants.APP_TVNOW, 1, [constants.APP_TVNOW], None],
             (constants.STATE_PAUSED, constants.APP_TVNOW, [constants.APP_TVNOW], None),
         )
 
         self.assertUpdate(
-            [True, True, 1, constants.APP_TVNOW, 4, [constants.APP_TVNOW], None],
+            [True, True, 4, constants.APP_TVNOW, 1, [constants.APP_TVNOW], None],
             (constants.STATE_PLAYING, constants.APP_TVNOW, [constants.APP_TVNOW], None),
         )
 
         self.assertUpdate(
-            [True, True, 1, constants.APP_TVNOW, 5, [constants.APP_TVNOW], None],
+            [True, True, 5, constants.APP_TVNOW, 1, [constants.APP_TVNOW], None],
             (constants.STATE_PLAYING, constants.APP_TVNOW, [constants.APP_TVNOW], None),
         )
 
         self.assertUpdate(
-            [True, True, 1, constants.APP_TVNOW, 6, [constants.APP_TVNOW], None],
+            [True, True, 6, constants.APP_TVNOW, 1, [constants.APP_TVNOW], None],
             (constants.STATE_IDLE, constants.APP_TVNOW, [constants.APP_TVNOW], None),
         )
 

--- a/tests/test_firetv_sync.py
+++ b/tests/test_firetv_sync.py
@@ -329,22 +329,22 @@ class TestFireTVSyncPython(unittest.TestCase):
         # TV NOW (Germany)
         self.assertUpdate(
             [True, True, 1, constants.APP_TV_NOW, 3, [constants.APP_TV_NOW], None],
-            (constants.STATE_PAUSED, constants.APP_TV_NOW, [constants.APP_TV_NOW], None)
+            (constants.STATE_PAUSED, constants.APP_TV_NOW, [constants.APP_TV_NOW], None),
         )
 
         self.assertUpdate(
             [True, True, 1, constants.APP_TV_NOW, 4, [constants.APP_TV_NOW], None],
-            (constants.STATE_PLAYING, constants.APP_TV_NOW, [constants.APP_TV_NOW], None)
+            (constants.STATE_PLAYING, constants.APP_TV_NOW, [constants.APP_TV_NOW], None),
         )
 
         self.assertUpdate(
             [True, True, 1, constants.APP_TV_NOW, 5, [constants.APP_TV_NOW], None],
-            (constants.STATE_PLAYING, constants.APP_TV_NOW, [constants.APP_TV_NOW], None)
+            (constants.STATE_PLAYING, constants.APP_TV_NOW, [constants.APP_TV_NOW], None),
         )
 
         self.assertUpdate(
             [True, True, 1, constants.APP_TV_NOW, 6, [constants.APP_TV_NOW], None],
-            (constants.STATE_IDLE, constants.APP_TV_NOW, [constants.APP_TV_NOW], None)
+            (constants.STATE_IDLE, constants.APP_TV_NOW, [constants.APP_TV_NOW], None),
         )
 
         # Twitch


### PR DESCRIPTION
# RTL PLUS
![](https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSTmKPYL3k4KLpTVhTC-HIlpNympWwxrM9WY79c7jJ2&s)
## 📝 Proposed Changes:
- Adds support for the german TV Streaming App "RTL Plus" (formerly TVNOW)
- The wake_lock states were observed via the ADB console
## ⚙️ CI Pipeline
- ✅  Passing
- ✅  Ready for Review