### PR TITLE
Switch usage of asyncio.wait_for to async_timeout

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -30,7 +30,7 @@ jobs:
         if python --version 2>&1 | grep -q "Python 2"; then pip install mock rsa==4.0; fi
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
         pip install .
-        if python --version 2>&1 | grep -q "Python 3.7" || python --version 2>&1 | grep -q "Python 3.8" || python --version 2>&1 | grep -q "Python 3.9" || python --version 2>&1 | grep -q "Python 3.10"; then pip install aiofiles adb-shell[usb]; fi
+        if python --version 2>&1 | grep -q "Python 3.7" || python --version 2>&1 | grep -q "Python 3.8" || python --version 2>&1 | grep -q "Python 3.9" || python --version 2>&1 | grep -q "Python 3.10"; then pip install aiofiles async_timeout adb-shell[usb]; fi
     - name: Check formatting with black
       run: |
         if python --version 2>&1 | grep -q "Python 3.7" || python --version 2>&1 | grep -q "Python 3.8" || python --version 2>&1 | grep -q "Python 3.9" || python --version 2>&1 | grep -q "Python 3.10"; then pip install black && make lint-black; fi

--- a/androidtv/adb_manager/adb_manager_async.py
+++ b/androidtv/adb_manager/adb_manager_async.py
@@ -15,6 +15,7 @@ from adb_shell.adb_device_async import AdbDeviceTcpAsync
 from adb_shell.auth.sign_pythonrsa import PythonRSASigner
 from adb_shell.constants import DEFAULT_PUSH_MODE, DEFAULT_READ_TIMEOUT_S
 import aiofiles
+import async_timeout
 from ppadb.client import Client
 
 from ..constants import (
@@ -164,7 +165,8 @@ async def _acquire(lock, timeout=DEFAULT_LOCK_TIMEOUT_S):
     try:
         acquired = False
         try:
-            acquired = await asyncio.wait_for(lock.acquire(), timeout)
+            async with async_timeout.timeout(timeout):
+                acquired = await lock.acquire()
             if not acquired:
                 raise LockNotAcquiredException
             yield acquired

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     author_email="jefflirion@users.noreply.github.com",
     packages=["androidtv", "androidtv.adb_manager", "androidtv.basetv", "androidtv.androidtv", "androidtv.firetv"],
     install_requires=["adb-shell>=0.4.0", "pure-python-adb>=0.3.0.dev0"],
-    extras_require={"async": ["aiofiles>=0.4.0"], "usb": ["adb-shell[usb]>=0.4.0"]},
+    extras_require={"async": ["aiofiles>=0.4.0", "async_timeout>=3.0.0"], "usb": ["adb-shell[usb]>=0.4.0"]},
     classifiers=[
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",


### PR DESCRIPTION
`asyncio.wait_for` creates another tasks which leads to some race conditions in cancelation and a performance hit

cpython 3.12 will change the underlying implementation of `asyncio.wait_for` to use `asyncio.wait` but that is still a long way off for many people:

https://github.com/python/cpython/pull/98518

seen on profile courtesy of @Madelena

![wait_for](https://github.com/JeffLIrion/python-androidtv/assets/663432/861d5546-e285-40e0-b9c4-c7635ae18cde)
