### PR TITLE
Add -A option to ps command to list all Fire TV processes

### DIFF
--- a/androidtv/basetv/basetv.py
+++ b/androidtv/basetv/basetv.py
@@ -324,10 +324,7 @@ class BaseTV(object):  # pylint: disable=too-few-public-methods
         if constants.CUSTOM_RUNNING_APPS in self._custom_commands:
             return self._custom_commands[constants.CUSTOM_RUNNING_APPS]
 
-        if self.DEVICE_ENUM == constants.DeviceEnum.FIRETV:
-            return constants.CMD_RUNNING_APPS_FIRETV
-
-        return constants.CMD_RUNNING_APPS_ANDROIDTV
+        return constants.CMD_RUNNING_APPS
 
     def _cmd_turn_off(self):
         """Get the command used to turn off this device.

--- a/androidtv/constants.py
+++ b/androidtv/constants.py
@@ -209,7 +209,7 @@ CMD_CURRENT_APP_MEDIA_SESSION_STATE_GOOGLE_TV = CMD_CURRENT_APP_GOOGLE_TV + " &&
 CMD_RUNNING_APPS_ANDROIDTV = "ps -A | grep u0_a"
 
 #: Get the running apps for a Fire TV device
-CMD_RUNNING_APPS_FIRETV = "ps | grep u0_a"
+CMD_RUNNING_APPS_FIRETV = "ps -A | grep u0_a"
 
 #: Get installed apps
 CMD_INSTALLED_APPS = "pm list packages"

--- a/androidtv/constants.py
+++ b/androidtv/constants.py
@@ -205,11 +205,8 @@ CMD_CURRENT_APP_MEDIA_SESSION_STATE13 = CMD_CURRENT_APP13 + " && " + CMD_MEDIA_S
 #: Determine the current app and get the state from ``dumpsys media_session`` for a Google TV device
 CMD_CURRENT_APP_MEDIA_SESSION_STATE_GOOGLE_TV = CMD_CURRENT_APP_GOOGLE_TV + " && " + CMD_MEDIA_SESSION_STATE
 
-#: Get the running apps for an Android TV device
-CMD_RUNNING_APPS_ANDROIDTV = "ps -A | grep u0_a"
-
-#: Get the running apps for a Fire TV device
-CMD_RUNNING_APPS_FIRETV = "ps | grep u0_a"
+#: Get the running apps for an Android/Fire TV device
+CMD_RUNNING_APPS = "ps -A | grep u0_a"
 
 #: Get installed apps
 CMD_INSTALLED_APPS = "pm list packages"

--- a/androidtv/constants.py
+++ b/androidtv/constants.py
@@ -209,7 +209,7 @@ CMD_CURRENT_APP_MEDIA_SESSION_STATE_GOOGLE_TV = CMD_CURRENT_APP_GOOGLE_TV + " &&
 CMD_RUNNING_APPS_ANDROIDTV = "ps -A | grep u0_a"
 
 #: Get the running apps for a Fire TV device
-CMD_RUNNING_APPS_FIRETV = "ps -A | grep u0_a"
+CMD_RUNNING_APPS_FIRETV = "ps | grep u0_a"
 
 #: Get installed apps
 CMD_INSTALLED_APPS = "pm list packages"

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -212,11 +212,8 @@ class TestConstants(unittest.TestCase):
         # CMD_MODEL
         self.assertCommand(constants.CMD_MODEL, r"getprop ro.product.model")
 
-        # CMD_RUNNING_APPS_ANDROIDTV
-        self.assertCommand(constants.CMD_RUNNING_APPS_ANDROIDTV, r"ps -A | grep u0_a")
-
-        # CMD_RUNNING_APPS_FIRETV
-        self.assertCommand(constants.CMD_RUNNING_APPS_FIRETV, r"ps | grep u0_a")
+        # CMD_RUNNING_APPS
+        self.assertCommand(constants.CMD_RUNNING_APPS, r"ps -A | grep u0_a")
 
         # CMD_SCREEN_ON
         self.assertCommand(

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -216,7 +216,7 @@ class TestConstants(unittest.TestCase):
         self.assertCommand(constants.CMD_RUNNING_APPS_ANDROIDTV, r"ps -A | grep u0_a")
 
         # CMD_RUNNING_APPS_FIRETV
-        self.assertCommand(constants.CMD_RUNNING_APPS_FIRETV, r"ps | grep u0_a")
+        self.assertCommand(constants.CMD_RUNNING_APPS_FIRETV, r"ps -A | grep u0_a")
 
         # CMD_SCREEN_ON
         self.assertCommand(

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -216,7 +216,7 @@ class TestConstants(unittest.TestCase):
         self.assertCommand(constants.CMD_RUNNING_APPS_ANDROIDTV, r"ps -A | grep u0_a")
 
         # CMD_RUNNING_APPS_FIRETV
-        self.assertCommand(constants.CMD_RUNNING_APPS_FIRETV, r"ps -A | grep u0_a")
+        self.assertCommand(constants.CMD_RUNNING_APPS_FIRETV, r"ps | grep u0_a")
 
         # CMD_SCREEN_ON
         self.assertCommand(


### PR DESCRIPTION
Fixes [#102565](https://github.com/home-assistant/core/issues/102565) and [https://github.com/JeffLIrion/python-androidtv/issues/292](https://github.com/JeffLIrion/python-androidtv/issues/292) and updates [https://github.com/JeffLIrion/python-androidtv/commit/e8b09aab7931a65be7e9beb71409c079da172b43](https://github.com/JeffLIrion/python-androidtv/commit/e8b09aab7931a65be7e9beb71409c079da172b43)