### PR TITLE
Documentation fix

### DIFF
--- a/androidtv/basetv/basetv.py
+++ b/androidtv/basetv/basetv.py
@@ -423,6 +423,9 @@ class BaseTV(object):  # pylint: disable=too-few-public-methods
         properties : str, None
             The output of the ADB command that retrieves the device properties
 
+        Returns
+        -------
+        None
         This method fills in the ``device_properties`` attribute, which is a dictionary with keys
         ``'serialno'``, ``'manufacturer'``, ``'model'``, ``'sw_version'`` and ``'product_id'``
 


### PR DESCRIPTION
As described in https://github.com/JeffLIrion/python-androidtv/pull/354#issuecomment-2452983137

Bug in the documentation for the _parse_device_properties function here:

https://androidtv.readthedocs.io/en/stable/androidtv.basetv.basetv.html#androidtv.basetv.basetv.BaseTV._parse_device_properties

The "Returns" section header is missing in the code and consequently all the documentation for that function is showing up incorrectly under Parameters