### PR TITLE
fix: empty manufacturer lead to failed parse_device_properties

### DIFF
--- a/androidtv/basetv/basetv.py
+++ b/androidtv/basetv/basetv.py
@@ -439,11 +439,17 @@ class BaseTV(object):  # pylint: disable=too-few-public-methods
             return
 
         lines = properties.strip().splitlines()
-        if len(lines) != 5:
+        if len(lines) != 7:
+            _LOGGER.warning(
+                "%s:%d `get_device_properties` Invalid response length: %s",
+                self.host,
+                self.port,
+                properties,
+            )
             self.device_properties = {}
             return
 
-        manufacturer, model, serialno, version, product_id = lines
+        _, manufacturer, model, serialno, version, product_id, _ = lines
 
         if not serialno.strip():
             _LOGGER.warning(

--- a/androidtv/constants.py
+++ b/androidtv/constants.py
@@ -257,6 +257,7 @@ CMD_MODEL = "getprop ro.product.model"
 CMD_SERIALNO = "getprop ro.serialno"
 CMD_VERSION = "getprop ro.build.version.release"
 CMD_PRODUCT_ID = "getprop ro.product.vendor.device"
+CMD_ECHO_PLACEHOLDER = "echo %"
 
 # Commands for getting the MAC address
 CMD_MAC_WLAN0 = "ip addr show wlan0 | grep -m 1 ether"
@@ -264,7 +265,7 @@ CMD_MAC_ETH0 = "ip addr show eth0 | grep -m 1 ether"
 
 #: The command used for getting the device properties
 CMD_DEVICE_PROPERTIES = (
-    CMD_MANUFACTURER + " && " + CMD_MODEL + " && " + CMD_SERIALNO + " && " + CMD_VERSION + " && " + CMD_PRODUCT_ID
+    CMD_ECHO_PLACEHOLDER + " && " + CMD_MANUFACTURER + " && " + CMD_MODEL + " && " + CMD_SERIALNO + " && " + CMD_VERSION + " && " + CMD_PRODUCT_ID + " && " + CMD_ECHO_PLACEHOLDER
 )
 
 


### PR DESCRIPTION
My tv returns empty with `getprop ro.product.manufacturer`

![image](https://github.com/user-attachments/assets/9d7a75d3-f539-4af7-bac2-533326e73c27)

this leads the `.strip()` removed the empty line and `properties` will become only 4 lines. `_parse_device_properties` will stop parsing.

if android version is not parsed, the library will use wrong command to get state and control the device.

I added two `echo %` line in the begin and end of the "get properties" command to prevent empty manufacturer to be erased by strip