### PR TITLE
Drop support for python 3.7 in CI

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
 
     steps:
     - uses: actions/checkout@v2

--- a/Makefile
+++ b/Makefile
@@ -113,18 +113,18 @@ pre-commit: .git/hooks/pre-commit  ## Create the pre-commit hook
 # Linting and code analysis
 .PHONY: black
 black: venv  ## Format the code using black
-	$(BLACK) --safe --line-length 120 --target-version py35 $(PACKAGE_DIR)
-	$(BLACK) --safe --line-length 120 --target-version py35 $(TEST_DIR)
+	$(BLACK) --safe --line-length 120 --target-version py38 $(PACKAGE_DIR)
+	$(BLACK) --safe --line-length 120 --target-version py38 $(TEST_DIR)
 ifneq ("$(wildcard setup.py)", "")
-	$(BLACK) --safe --line-length 120 --target-version py35 setup.py
+	$(BLACK) --safe --line-length 120 --target-version py38 setup.py
 endif
 
 .PHONY: lint-black
 lint-black: venv  ## Check that the code is formatted using black
-	$(BLACK) --check --line-length 120 --safe --target-version py35 $(PACKAGE_DIR)
-	$(BLACK) --check --line-length 120 --safe --target-version py35 $(TEST_DIR)
+	$(BLACK) --check --line-length 120 --safe --target-version py38 $(PACKAGE_DIR)
+	$(BLACK) --check --line-length 120 --safe --target-version py38 $(TEST_DIR)
 ifneq ("$(wildcard setup.py)", "")
-	$(BLACK) --check --line-length 120 --safe --target-version py35 setup.py
+	$(BLACK) --check --line-length 120 --safe --target-version py38 setup.py
 endif
 
 .PHONY: lint-flake8

--- a/androidtv/exceptions.py
+++ b/androidtv/exceptions.py
@@ -1,6 +1,4 @@
-"""Exceptions for use throughout the code.
-
-"""
+"""Exceptions for use throughout the code."""
 
 
 class LockNotAcquiredException(Exception):


### PR DESCRIPTION
In CI:

1 error and 1 warning
[build (3.7)](https://github.com/JeffLIrion/python-androidtv/actions/runs/12251553974/job/34176401558#logs)
failed on Dec 10, 2024 in 3s

```
Run actions/setup-python@v2
Version 3.7 was not found in the local cache
Error: Version 3.[7](https://github.com/JeffLIrion/python-androidtv/actions/runs/12251553974/job/34176401558#step:3:8) with arch x64 not found
The list of all available versions can be found here: https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
```