### PR TITLE
Use `dumpsys deviceidle get screen` in CMD_SCREEN_ON

### DIFF
--- a/androidtv/constants.py
+++ b/androidtv/constants.py
@@ -226,7 +226,7 @@ CMD_RUNNING_APPS = "ps -A | grep u0_a"
 CMD_INSTALLED_APPS = "pm list packages"
 
 #: Determine if the device is on
-CMD_SCREEN_ON = "(dumpsys power | grep 'Display Power' | grep -q 'state=ON' || dumpsys power | grep -q 'mScreenOn=true' || dumpsys display | grep -q 'mScreenState=ON')"
+CMD_SCREEN_ON = "(dumpsys deviceidle get screen | grep true || dumpsys power | grep 'Display Power' | grep 'state=ON' || dumpsys power | grep 'mScreenOn=true' || dumpsys display | grep 'mScreenState=ON') > /dev/null"
 
 #: Get the "STREAM_MUSIC" block from ``dumpsys audio``
 CMD_STREAM_MUSIC = r"dumpsys audio | grep '\- STREAM_MUSIC:' -A 11"

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -231,13 +231,13 @@ class TestConstants(unittest.TestCase):
         # CMD_SCREEN_ON
         self.assertCommand(
             constants.CMD_SCREEN_ON,
-            r"(dumpsys power | grep 'Display Power' | grep -q 'state=ON' || dumpsys power | grep -q 'mScreenOn=true' || dumpsys display | grep -q 'mScreenState=ON')",
+            r"(dumpsys deviceidle get screen | grep true || dumpsys power | grep 'Display Power' | grep 'state=ON' || dumpsys power | grep 'mScreenOn=true' || dumpsys display | grep 'mScreenState=ON') > /dev/null",
         )
 
         # CMD_SCREEN_ON_AWAKE_WAKE_LOCK_SIZE
         self.assertCommand(
             constants.CMD_SCREEN_ON_AWAKE_WAKE_LOCK_SIZE,
-            r"(dumpsys power | grep 'Display Power' | grep -q 'state=ON' || dumpsys power | grep -q 'mScreenOn=true' || dumpsys display | grep -q 'mScreenState=ON') && echo -e '1\c' || echo -e '0\c' && dumpsys power | grep mWakefulness | grep -q Awake && echo -e '1\c' || echo -e '0\c' && dumpsys power | grep Locks | grep 'size='",
+            r"(dumpsys deviceidle get screen | grep true || dumpsys power | grep 'Display Power' | grep 'state=ON' || dumpsys power | grep 'mScreenOn=true' || dumpsys display | grep 'mScreenState=ON') > /dev/null && echo -e '1\c' || echo -e '0\c' && dumpsys power | grep mWakefulness | grep -q Awake && echo -e '1\c' || echo -e '0\c' && dumpsys power | grep Locks | grep 'size='",
         )
 
         # CMD_SERIALNO
@@ -249,25 +249,25 @@ class TestConstants(unittest.TestCase):
         # CMD_TURN_OFF_ANDROIDTV
         self.assertCommand(
             constants.CMD_TURN_OFF_ANDROIDTV,
-            r"(dumpsys power | grep 'Display Power' | grep -q 'state=ON' || dumpsys power | grep -q 'mScreenOn=true' || dumpsys display | grep -q 'mScreenState=ON') && input keyevent 26",
+            r"(dumpsys deviceidle get screen | grep true || dumpsys power | grep 'Display Power' | grep 'state=ON' || dumpsys power | grep 'mScreenOn=true' || dumpsys display | grep 'mScreenState=ON') > /dev/null && input keyevent 26",
         )
 
         # CMD_TURN_OFF_FIRETV
         self.assertCommand(
             constants.CMD_TURN_OFF_FIRETV,
-            r"(dumpsys power | grep 'Display Power' | grep -q 'state=ON' || dumpsys power | grep -q 'mScreenOn=true' || dumpsys display | grep -q 'mScreenState=ON') && input keyevent 223",
+            r"(dumpsys deviceidle get screen | grep true || dumpsys power | grep 'Display Power' | grep 'state=ON' || dumpsys power | grep 'mScreenOn=true' || dumpsys display | grep 'mScreenState=ON') > /dev/null && input keyevent 223",
         )
 
         # CMD_TURN_ON_ANDROIDTV
         self.assertCommand(
             constants.CMD_TURN_ON_ANDROIDTV,
-            r"(dumpsys power | grep 'Display Power' | grep -q 'state=ON' || dumpsys power | grep -q 'mScreenOn=true' || dumpsys display | grep -q 'mScreenState=ON') || input keyevent 26",
+            r"(dumpsys deviceidle get screen | grep true || dumpsys power | grep 'Display Power' | grep 'state=ON' || dumpsys power | grep 'mScreenOn=true' || dumpsys display | grep 'mScreenState=ON') > /dev/null || input keyevent 26",
         )
 
         # CMD_TURN_ON_FIRETV
         self.assertCommand(
             constants.CMD_TURN_ON_FIRETV,
-            r"(dumpsys power | grep 'Display Power' | grep -q 'state=ON' || dumpsys power | grep -q 'mScreenOn=true' || dumpsys display | grep -q 'mScreenState=ON') || (input keyevent 26 && input keyevent 3)",
+            r"(dumpsys deviceidle get screen | grep true || dumpsys power | grep 'Display Power' | grep 'state=ON' || dumpsys power | grep 'mScreenOn=true' || dumpsys display | grep 'mScreenState=ON') > /dev/null || (input keyevent 26 && input keyevent 3)",
         )
 
         # CMD_VERSION


### PR DESCRIPTION
This PR:
- fixes a broken pipe like in #351, but from `grep -q` instead of `grep -m 1`
- uses a much more efficient call to get screen state

On Android 14, both `dumpsys power` greps no longer match. It prints `Display Power: com.android.server.power.PowerManagerService$1@a8a75e6` with no `state=` field, and `mScreenOn=true` is gone. So each poll, every 10 seconds, falls back to `dumpsys display`, a much more expensive call.

EDIT: Tested on LineageOS 21 (Android 14, SDK 34), x86_64 Android TV.

Because `grep -q` terminates on first match, the pipe is broken, resulting in a stack trace every 10 seconds that looks like:

```
W FastPrintWriter: Write failure
W FastPrintWriter: java.io.IOException: write failed: EPIPE (Broken pipe)
W FastPrintWriter: 	at libcore.io.IoBridge.write(IoBridge.java:651)
W FastPrintWriter: 	at java.io.FileOutputStream.write(FileOutputStream.java:432)
W FastPrintWriter: 	at com.android.internal.util.FastPrintWriter.flushBytesLocked(FastPrintWriter.java:355)
W FastPrintWriter: 	at com.android.internal.util.FastPrintWriter.flushLocked(FastPrintWriter.java:378)
W FastPrintWriter: 	at com.android.internal.util.FastPrintWriter.flush(FastPrintWriter.java:413)
W FastPrintWriter: 	at android.os.Binder.dump(Binder.java:1158)
W FastPrintWriter: 	at android.os.Binder.onTransact(Binder.java:1022)
W FastPrintWriter: Caused by: android.system.ErrnoException: write failed: EPIPE (Broken pipe)
W FastPrintWriter: 	at libcore.io.IoBridge.write(IoBridge.java:646)
W FastPrintWriter: 	... 9 more
```

This PR fixes the issue:
- uses `dumpsys deviceidle get screen` to check screen state, which is cheap and has been available since Android 7
  - https://android.googlesource.com/platform/frameworks/base/+/android-7.0.0_r1/services/core/java/com/android/server/DeviceIdleController.java
- removes `-q` so grep will not stop on first match and cause broken pipe
  - `> /dev/null` is now needed to replace output suppression that `-q` provided